### PR TITLE
GlobalException 및 공통 응답값 커스텀

### DIFF
--- a/src/main/java/teamyc/recordpet/domain/user/controller/UserController.java
+++ b/src/main/java/teamyc/recordpet/domain/user/controller/UserController.java
@@ -8,14 +8,17 @@ import org.springframework.web.bind.annotation.RestController;
 import teamyc.recordpet.domain.user.dto.UserSignupRequest;
 import teamyc.recordpet.domain.user.dto.UserSignupResponse;
 import teamyc.recordpet.domain.user.service.UserService;
+import teamyc.recordpet.global.exception.CustomResponse;
 
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
+
     private final UserService userService;
+
     @PostMapping("/signup")
-    public UserSignupResponse signup(@RequestBody UserSignupRequest req){
-        return userService.signup(req);
+    public CustomResponse<UserSignupResponse> signup(@RequestBody UserSignupRequest req) {
+        return CustomResponse.success(userService.signup(req));
     }
 }

--- a/src/main/java/teamyc/recordpet/domain/user/service/UserService.java
+++ b/src/main/java/teamyc/recordpet/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package teamyc.recordpet.domain.user.service;
 
+import static teamyc.recordpet.global.exception.ResultCode.*;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -7,6 +9,7 @@ import teamyc.recordpet.domain.user.dto.UserSignupRequest;
 import teamyc.recordpet.domain.user.dto.UserSignupResponse;
 import teamyc.recordpet.domain.user.entity.User;
 import teamyc.recordpet.domain.user.repository.UserRepository;
+import teamyc.recordpet.global.exception.GlobalException;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +32,7 @@ public class UserService {
 
     private void checkDuplicateEmail(UserSignupRequest req) {
         if (userRepository.existsByEmail(req.getEmail())) {
-            throw new IllegalArgumentException("중복 이메일");
+            throw new GlobalException(DUPLICATE_USER_EMAIL);
         }
     }
 }

--- a/src/main/java/teamyc/recordpet/global/exception/CustomResponse.java
+++ b/src/main/java/teamyc/recordpet/global/exception/CustomResponse.java
@@ -1,0 +1,33 @@
+package teamyc.recordpet.global.exception;
+
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class CustomResponse<T> implements Serializable {
+
+    private HttpStatus httpStatus;
+    private String code;
+    private String message;
+    private T data;
+
+    public static <T> CustomResponse<T> success(T data) {
+        return CustomResponse.<T>builder()
+            .httpStatus(ResultCode.SUCCESS.getHttpStatus())
+            .code(ResultCode.SUCCESS.getCode())
+            .message(ResultCode.SUCCESS.getMessage())
+            .data(data)
+            .build();
+    }
+
+    public static <T> CustomResponse<T> error(ResultCode resultCode) {
+        return CustomResponse.<T>builder()
+            .httpStatus(resultCode.getHttpStatus())
+            .code(resultCode.getCode())
+            .message(resultCode.getMessage())
+            .build();
+    }
+}

--- a/src/main/java/teamyc/recordpet/global/exception/GlobalException.java
+++ b/src/main/java/teamyc/recordpet/global/exception/GlobalException.java
@@ -1,0 +1,11 @@
+package teamyc.recordpet.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GlobalException extends RuntimeException {
+
+    private final ResultCode resultCode;
+}

--- a/src/main/java/teamyc/recordpet/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/teamyc/recordpet/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,13 @@
+package teamyc.recordpet.global.exception;
+
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public CustomResponse<Void> handleException(GlobalException e) {
+        return CustomResponse.error(e.getResultCode());
+    }
+}

--- a/src/main/java/teamyc/recordpet/global/exception/ResultCode.java
+++ b/src/main/java/teamyc/recordpet/global/exception/ResultCode.java
@@ -1,0 +1,21 @@
+package teamyc.recordpet.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResultCode {
+    // Success
+    SUCCESS("Success", "정상 처리 되었습니다.", HttpStatus.OK),
+
+    // User U-
+    DUPLICATE_USER_EMAIL("U001", "이미 가입된 이메일 입니다.", HttpStatus.CONFLICT);
+
+    // Pet P-
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}


### PR DESCRIPTION
## 📌 작업 내용
### 이 PR에서 변경된 내용은 무엇인가요?
- [x] 주요 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가
### 작업 내용 상세 설명:
- *핵심 변경 사항*:
  - GlobalExceptionHandler 추가
  - 응답 코드 세분화를 위한 커스텀 예외 코드인 ResultCode  추가
  - 공통 응답값 처리를 위한 CustomResponse 추가
- *보완 사항*:
    - 기존 Controller 응답값 CustomResponse로 수정
---
## 🛠️ 해결한 이슈
- 관련된 이슈 번호
    - close #3
---
## 🤝 리뷰어에게 요청 사항

---
## 💚 적용 결과
![image](https://github.com/user-attachments/assets/ef5a8e20-c5b8-4b8d-b9b8-937f8f994240)
![image](https://github.com/user-attachments/assets/7e9684e2-0313-4ed1-8ca9-2917247d11b6)
---
## 🔗 참고사항
- 아직 각 서비스 모듈에서 Result Code 라는 공통 모듈을 참조하고 있어 분리가 제대로 이뤄지지 않았음, 아래 코드 참고해 추후 변경 예정
    - (링크)](https://velog.io/@letsdev/Spring-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC-%EC%89%BD%EA%B2%8C-%EA%B4%80%EC%8B%AC%EC%82%AC-%EB%82%98%EB%88%84%EA%B8%B0-Global-Exception-HandlerController-Advice)